### PR TITLE
Update boss_cthun.cpp

### DIFF
--- a/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_cthun.cpp
+++ b/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_cthun.cpp
@@ -296,7 +296,7 @@ public:
                         {
                             //Face our target
                             DarkGlareAngle = me->GetAngle(target);
-                            DarkGlareTickTimer = 1000;
+                            DarkGlareTickTimer = 4000;
                             DarkGlareTick = 0;
                             ClockWise = RAND(true, false);
                         }


### PR DESCRIPTION
C'Thun Dark Glare spell should be casted 4 seconds after C'Thun turns red, but is currently casting just after 1 second.

https://youtu.be/vZcR-OcrJGg?t=70